### PR TITLE
An overridable primary color per component.

### DIFF
--- a/src/ReCyCleTheme.js
+++ b/src/ReCyCleTheme.js
@@ -5,7 +5,8 @@ import RobotoLight from 'typeface-roboto/files/roboto-latin-300.woff2';
 import RobotoRegular from 'typeface-roboto/files/roboto-latin-400.woff2';
 import RobotoMedium from 'typeface-roboto/files/roboto-latin-500.woff2';
 import RobotoBold from 'typeface-roboto/files/roboto-latin-700.woff2';
-import { defaultConfig, overridablePrimaryColors } from './config';
+import { defaultConfig, themeOverrides } from './config';
+import { mapValues } from 'lodash';
 
 const injectGlobalStyles = theme => injectGlobal`
     @font-face {
@@ -64,16 +65,18 @@ export default class ReCyCleTheme extends Component {
         theme: PropTypes.object,
         children: PropTypes.node,
     };
+    static defaultProps = {
+        theme: {},
+    };
     getTheme = () => {
         const theme = this.props.theme;
-        const primaryColor = theme.primaryColor || defaultConfig.primaryColor;
-
-        // Object with every overridable primaryColorProp set to the primaryColor
-        // of the given theme.
-        const fallback = {};
-        overridablePrimaryColors.forEach(propName => {
-            fallback[propName] = primaryColor;
-        });
+        // Fallback to the value of the fallbackProp
+        const fallback = mapValues(
+            themeOverrides,
+            (fallbackProp, overrideProp) => {
+                return theme[fallbackProp] || defaultConfig[fallbackProp];
+            }
+        );
 
         return Object.assign({}, defaultConfig, fallback, theme);
     };

--- a/src/ReCyCleTheme.js
+++ b/src/ReCyCleTheme.js
@@ -5,7 +5,7 @@ import RobotoLight from 'typeface-roboto/files/roboto-latin-300.woff2';
 import RobotoRegular from 'typeface-roboto/files/roboto-latin-400.woff2';
 import RobotoMedium from 'typeface-roboto/files/roboto-latin-500.woff2';
 import RobotoBold from 'typeface-roboto/files/roboto-latin-700.woff2';
-import { defaultConfig } from './config';
+import { defaultConfig, overridablePrimaryColors } from './config';
 
 const injectGlobalStyles = theme => injectGlobal`
     @font-face {
@@ -65,7 +65,17 @@ export default class ReCyCleTheme extends Component {
         children: PropTypes.node,
     };
     getTheme = () => {
-        return Object.assign({}, defaultConfig, this.props.theme);
+        const theme = this.props.theme;
+        const primaryColor = theme.primaryColor || defaultConfig.primaryColor;
+
+        // Object with every overridable primaryColorProp set to the primaryColor
+        // of the given theme.
+        const fallback = {};
+        overridablePrimaryColors.forEach(propName => {
+            fallback[propName] = primaryColor;
+        });
+
+        return Object.assign({}, defaultConfig, fallback, theme);
     };
     componentDidMount() {
         injectGlobalStyles(this.getTheme());

--- a/src/config.js
+++ b/src/config.js
@@ -23,7 +23,13 @@ export const defaultConfig = {
     zIndexSingleDatePickerOverlay: 100,
 };
 
-export const overridablePrimaryColors = ['primaryButtonColor'];
+// overrideProp : fallbackProp
+// If overrideProps isn't specified in the recycleTheme,
+// we fall back to the value of the fallbackProp.
+export const themeOverrides = {
+    primaryButtonColor: 'primaryColor',
+    textHeadingColor: 'textColor',
+};
 
 // This uses YIQ to  calculate the color contrast.
 // Same calculation as Bootstrap uses, seems to work better than polished's `readableColor()`

--- a/src/config.js
+++ b/src/config.js
@@ -23,6 +23,8 @@ export const defaultConfig = {
     zIndexSingleDatePickerOverlay: 100,
 };
 
+export const overridablePrimaryColors = ['primaryButtonColor'];
+
 // This uses YIQ to  calculate the color contrast.
 // Same calculation as Bootstrap uses, seems to work better than polished's `readableColor()`
 export function readableColor(color) {

--- a/src/general/Button.js
+++ b/src/general/Button.js
@@ -75,7 +75,7 @@ export const Button = styled(props => (
         width: 100%;
     `};
     ${props => {
-        const background = props.theme[`${props.tone || 'primary'}Color`];
+        const background = props.theme[`${props.tone || 'primaryButton'}Color`];
         const textColor = `color: ${getTextColor(props, background)};`;
 
         if (props.icon) {

--- a/src/general/Button.stories.js
+++ b/src/general/Button.stories.js
@@ -7,6 +7,7 @@ import IconDelete from './icon/IconDelete';
 import IconSearch from './icon/IconSearch';
 import IconBuild from './icon/IconBuild';
 import IconMic from './icon/IconMic';
+import ReCyCleTheme from '../ReCyCleTheme';
 import CenterDecorator from '../../storybook/CenterDecorator';
 
 storiesOf('General / Button', module)
@@ -57,6 +58,20 @@ storiesOf('General / Button', module)
                         </Button>
                     </div>
                 </div>
+            );
+        })
+    )
+    .add(
+        'with an overwritten primaryColor',
+        withInfo()(() => {
+            return (
+                <ReCyCleTheme theme={{ primaryButtonColor: '#DE0000' }}>
+                    <div>
+                        <Button>Primary</Button>
+                        <Button tone="success">Success</Button>
+                        <Button tone="warning">Warning</Button>
+                    </div>
+                </ReCyCleTheme>
             );
         })
     )

--- a/src/general/typography/Heading.js
+++ b/src/general/typography/Heading.js
@@ -5,7 +5,7 @@ const Heading = styled.h1`
     font-weight: bold;
     font-size: 26px;
     margin: 20px 0 7px 0;
-    color: ${props => props.color || props.theme.textColor};
+    color: ${props => props.color || props.theme.textHeadingColor};
 `;
 Heading.displayName = 'Heading';
 Heading.propTypes = {


### PR DESCRIPTION
There currently are a lot of component which use the primaryColor. This can however look quite monotone, so you might want to have some components deviate from the primaryColor.

I think the best place to define such a deviation is in the ReCyCleTheme.

In the current implementation: users can specify a primaryButtonColor. If it is not specified, it will fallback to the theme's primaryColor.

In this PR, this fallback is handled in `ReCyCleTheme.getTheme`, where a fallback object is created based on `config.overridablePrimaryColors`. We cannot simply set these defaults in `config.defaultConfig` as the values need to fall back to the primaryColor provided in the ReCyCleTheme theme props.

`getTheme` however is executed quite often when clicking through storybook, but I was unsure if this needed fixing in re-cy-cle or was just inherent to how storybook works.